### PR TITLE
chore: hint for the new DeleteDummyWorkitemsHook properties

### DIFF
--- a/delete-dummy-workitems/src/main/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHook.java
+++ b/delete-dummy-workitems/src/main/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHook.java
@@ -46,6 +46,11 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
             "      <li>there are incoming links for the current workitem (apart from links of other headings or has only parent links)</li>" +
             "      <li>workitem is not in 'Draft' status</li>" +
             "    </ul>" +
+            "  </li>" +
+            "</ul>" +
+            "Upgrading to <b>v3.2.0</b>:" +
+            "<ul>" +
+            "  <li>introduced two new properties: <b>docDraftStatusIds</b> and <b>workItemDraftStatusIds</b> - use them in case you have custom statuses IDs which must be treated as 'Draft'</li>"+
             "</ul>";
 
     public static final String SETTINGS_PROJECTS_DESCRIPTION = "Comma-separated list of projects. Use * to process all.";


### PR DESCRIPTION
### Proposed changes

We have to add a hint which will inform the user about new DeleteDummyWorkitemsHook properties.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
