### PR TITLE
feat: add bypass roles for users to skip the delete hook

### DIFF
--- a/delete-dummy-workitems/src/main/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHook.java
+++ b/delete-dummy-workitems/src/main/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHook.java
@@ -15,10 +15,12 @@ import com.polarion.platform.core.PlatformContext;
 import com.polarion.platform.persistence.IEnumOption;
 import com.polarion.platform.persistence.model.IPObject;
 import com.polarion.platform.persistence.model.IPObjectList;
+import com.polarion.platform.security.ISecurityService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -53,6 +55,10 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
             "Upgrading to <b>v3.2.0</b>:" +
             "<ul>" +
             "  <li>introduced two new properties: <b>docDraftStatusIds</b> and <b>workItemDraftStatusIds</b> - use them in case you have custom statuses IDs which must be treated as 'Draft'</li>" +
+            "</ul>" +
+            "Upgrading to <b>v5.1.0</b>:" +
+            "<ul>" +
+            "  <li>introduced two new properties: <b>bypassGlobalRoles</b> and <b>bypassProjectRoles</b> - use them to let users with the listed Polarion roles bypass this hook</li>" +
             "</ul>";
 
     public static final String SETTINGS_PROJECTS_DESCRIPTION = "Comma-separated list of projects. Use * to process all.";
@@ -82,6 +88,12 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
     public static final String SETTINGS_WORKITEM_DRAFT_STATUS_IDS_DESCRIPTION = "Comma-separated list of workitem status IDs which will be treated as 'Draft'";
     public static final String SETTINGS_WORKITEM_DRAFT_STATUS_IDS = "workItemDraftStatusIds";
 
+    public static final String SETTINGS_BYPASS_GLOBAL_ROLES_DESCRIPTION = "Comma-separated list of GLOBAL Polarion roles whose users bypass this hook in any project (e.g. admin).";
+    public static final String SETTINGS_BYPASS_GLOBAL_ROLES = "bypassGlobalRoles";
+
+    public static final String SETTINGS_BYPASS_PROJECT_ROLES_DESCRIPTION = "Comma-separated list of CONTEXTUAL (project) Polarion roles whose users bypass this hook for a particular project (e.g. bypassProjectRoles.projectId1=project_admin). Use bypassProjectRoles.* as the default for all projects.";
+    public static final String SETTINGS_BYPASS_PROJECT_ROLES = "bypassProjectRoles";
+
     private static final Logger logger = Logger.getLogger(DeleteDummyWorkitemsHook.class);
     public static final String PLACEHOLDER_WORK_ITEM_ID = "{workItemId}";
     public static final String PLACEHOLDER_PROJECT_LOCATION = "{projectLocation}";
@@ -90,6 +102,7 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
     public static final String PLACEHOLDER_DOCUMENT_NAME = "{documentName}";
 
     private final ITrackerService trackerService = PlatformContext.getPlatform().lookupService(ITrackerService.class);
+    private final ISecurityService securityService = PlatformContext.getPlatform().lookupService(ISecurityService.class);
 
     public DeleteDummyWorkitemsHook() {
         super(ItemType.WORKITEM, ActionType.DELETE, DESCRIPTION);
@@ -104,6 +117,10 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
 
         if (!shouldHookBeRun(project, workItem)) {
             return null; // the hook is not applicable for project or workitem type
+        }
+
+        if (currentUserHasBypassRole(project)) {
+            return null; // current user has a role configured to bypass this hook
         }
 
         String projectLocation = project.getLocation().getLocationPath();
@@ -178,6 +195,26 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
     @Override
     public @NotNull HookExecutor getExecutor() {
         return this;
+    }
+
+    private boolean currentUserHasBypassRole(@NotNull ITrackerProject project) {
+        String currentUser = securityService.getCurrentUser();
+        if (StringUtils.isEmpty(currentUser)) {
+            return false;
+        }
+
+        List<String> bypassGlobalRoles = new ArrayList<>(getSettingsValueAsList(SETTINGS_BYPASS_GLOBAL_ROLES));
+        List<String> bypassProjectRoles = new ArrayList<>(getSettingsValueAsList(SETTINGS_BYPASS_PROJECT_ROLES, project.getId()));
+        if (bypassGlobalRoles.isEmpty() && bypassProjectRoles.isEmpty()) {
+            return false;
+        }
+
+        Collection<String> globalRoles = securityService.getRolesForUser(currentUser);
+        if (globalRoles.stream().anyMatch(bypassGlobalRoles::contains)) {
+            return true;
+        }
+        Collection<String> projectRoles = securityService.getContextRolesForUser(currentUser, project.getContextId());
+        return projectRoles.stream().anyMatch(bypassProjectRoles::contains);
     }
 
     private boolean shouldHookBeRun(@NotNull ITrackerProject project, @NotNull IWorkItem workItem) {
@@ -303,6 +340,12 @@ public class DeleteDummyWorkitemsHook extends ActionHook implements HookExecutor
                         SETTINGS_DOCUMENT_DRAFT_STATUS_IDS, STATUS_DRAFT,
                         SETTINGS_WORKITEM_DRAFT_STATUS_IDS_DESCRIPTION,
                         SETTINGS_WORKITEM_DRAFT_STATUS_IDS, STATUS_DRAFT) +
+                System.lineSeparator() +
+                PropertiesUtils.buildWithDescription(
+                        SETTINGS_BYPASS_GLOBAL_ROLES_DESCRIPTION,
+                        SETTINGS_BYPASS_GLOBAL_ROLES, "",
+                        SETTINGS_BYPASS_PROJECT_ROLES_DESCRIPTION,
+                        SETTINGS_BYPASS_PROJECT_ROLES + DOT + ALL_WILDCARD, "") +
                 System.lineSeparator() +
                 PropertiesUtils.build(
                         SETTINGS_ERROR_STATUS_MSG, "Cannot delete workitem '%s' in '%s'. The document '%s' is in status '%s'.".formatted(PLACEHOLDER_WORK_ITEM_ID, PLACEHOLDER_PROJECT_LOCATION, PLACEHOLDER_DOCUMENT_NAME, PLACEHOLDER_DOCUMENT_STATUS),

--- a/delete-dummy-workitems/src/test/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHookTest.java
+++ b/delete-dummy-workitems/src/test/java/ch/sbb/polarion/extension/interceptor_manager/hooks/delete_dummy_workitems/DeleteDummyWorkitemsHookTest.java
@@ -15,6 +15,8 @@ import com.polarion.core.util.logging.Logger;
 import com.polarion.platform.core.IPlatform;
 import com.polarion.platform.core.PlatformContext;
 import com.polarion.platform.persistence.model.IPObjectList;
+import com.polarion.platform.security.ISecurityService;
+import com.polarion.subterra.base.data.identification.IContextId;
 import com.polarion.subterra.base.location.ILocation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,12 +45,15 @@ class DeleteDummyWorkitemsHookTest {
     MockedStatic<HookManifestUtils> hookManifestUtilsMockedStatic;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ITrackerService trackerService;
+    @Mock
+    private ISecurityService securityService;
 
     @BeforeEach
     void setUp() {
         hookManifestUtilsMockedStatic.when(() -> HookManifestUtils.getHookVersion(any())).thenReturn("1.0.0");
         IPlatform platform = mock(IPlatform.class);
         when(platform.lookupService(ITrackerService.class)).thenReturn(trackerService);
+        when(platform.lookupService(ISecurityService.class)).thenReturn(securityService);
         platformContextMockedStatic.when(PlatformContext::getPlatform).thenReturn(platform);
     }
 
@@ -157,5 +162,141 @@ class DeleteDummyWorkitemsHookTest {
 
         when(historyStatus.getId()).thenReturn("draft");
         assertNull(deleteDummyWorkitemsHook.getExecutor().preAction(workItem));
+    }
+
+    @Test
+    void testBypassGlobalRole() {
+        IWorkItem workItem = buildBlockedWorkItem("testProject1");
+
+        DeleteDummyWorkitemsHook hook = createHookWithBypassRoles("admin", "", null);
+
+        when(securityService.getCurrentUser()).thenReturn("alice");
+        // alice has no contextual role in this project
+        lenient().when(securityService.getContextRolesForUser(eq("alice"), nullable(IContextId.class))).thenReturn(List.of());
+
+        // user without bypass role -> hook applies (module is in 'in_process' status)
+        when(securityService.getRolesForUser("alice")).thenReturn(List.of("project_developer"));
+        assertEquals("Cannot delete workitem 'EL-111' in '/testProject1'. The document 'TestModule' is in status 'In process'.",
+                hook.getExecutor().preAction(workItem));
+
+        // user with the configured global bypass role -> hook is skipped
+        when(securityService.getRolesForUser("alice")).thenReturn(List.of("admin"));
+        assertNull(hook.getExecutor().preAction(workItem));
+    }
+
+    @Test
+    void testBypassProjectSpecificRole() {
+        IWorkItem workItem = buildBlockedWorkItem("testProject1");
+
+        // bypass for testProject1 only; global empty; wildcard empty
+        DeleteDummyWorkitemsHook hook = createHookWithBypassRoles("", "", "project_admin");
+
+        when(securityService.getCurrentUser()).thenReturn("alice");
+        // alice has no global roles relevant for the bypass
+        when(securityService.getRolesForUser("alice")).thenReturn(List.of());
+
+        when(securityService.getContextRolesForUser(eq("alice"), nullable(IContextId.class))).thenReturn(List.of("project_admin"));
+        assertNull(hook.getExecutor().preAction(workItem));
+
+        when(securityService.getContextRolesForUser(eq("alice"), nullable(IContextId.class))).thenReturn(List.of("project_developer"));
+        assertEquals("Cannot delete workitem 'EL-111' in '/testProject1'. The document 'TestModule' is in status 'In process'.",
+                hook.getExecutor().preAction(workItem));
+    }
+
+    @Test
+    void testBypassProjectRoleScopedToAnotherProject() {
+        IWorkItem workItem = buildBlockedWorkItem("testProject1");
+
+        // bypass configured for a different project ("otherProject"); must NOT apply to testProject1
+        String settings = baseSettings() + System.lineSeparator() + "bypassProjectRoles.otherProject=project_admin";
+        DeleteDummyWorkitemsHook hook = createHookWithSettings(settings);
+
+        when(securityService.getCurrentUser()).thenReturn("alice");
+
+        // bypass lists resolved for testProject1 are empty -> role lookups must be skipped
+        assertEquals("Cannot delete workitem 'EL-111' in '/testProject1'. The document 'TestModule' is in status 'In process'.",
+                hook.getExecutor().preAction(workItem));
+        verify(securityService, never()).getRolesForUser(anyString());
+        verify(securityService, never()).getContextRolesForUser(anyString(), nullable(IContextId.class));
+    }
+
+    @Test
+    void testBypassProjectRolesWildcard() {
+        IWorkItem workItem = buildBlockedWorkItem("testProject1");
+
+        // wildcard project bypass (applies to every project)
+        DeleteDummyWorkitemsHook hook = createHookWithBypassRoles("", "project_admin", null);
+
+        when(securityService.getCurrentUser()).thenReturn("alice");
+        when(securityService.getRolesForUser("alice")).thenReturn(List.of());
+        when(securityService.getContextRolesForUser(eq("alice"), nullable(IContextId.class))).thenReturn(List.of("project_admin"));
+
+        assertNull(hook.getExecutor().preAction(workItem));
+    }
+
+    @Test
+    void testBypassNoRolesConfigured_roleLookupsSkipped() {
+        IWorkItem workItem = buildBlockedWorkItem("testProject1");
+
+        // defaults: empty bypassGlobalRoles + empty bypassProjectRoles.* -> role lookups must be skipped
+        DeleteDummyWorkitemsHook hook = createHookWithSettings(baseSettings());
+
+        when(securityService.getCurrentUser()).thenReturn("alice");
+
+        assertEquals("Cannot delete workitem 'EL-111' in '/testProject1'. The document 'TestModule' is in status 'In process'.",
+                hook.getExecutor().preAction(workItem));
+        verify(securityService, never()).getRolesForUser(anyString());
+        verify(securityService, never()).getContextRolesForUser(anyString(), nullable(IContextId.class));
+    }
+
+    private IWorkItem buildBlockedWorkItem(String projectId) {
+        IProjectGroup projectGroup = mock(IProjectGroup.class);
+        lenient().when(projectGroup.getName()).thenReturn("default");
+        lenient().when(projectGroup.getParentProjectGroup()).thenReturn(null);
+
+        ITrackerProject project = mock(ITrackerProject.class);
+        lenient().when(project.getProjectGroup()).thenReturn(projectGroup);
+        lenient().when(project.getId()).thenReturn(projectId);
+        ILocation location = mock(ILocation.class);
+        lenient().when(location.getLocationPath()).thenReturn("/" + projectId);
+        lenient().when(project.getLocation()).thenReturn(location);
+
+        IWorkItem workItem = mock(IWorkItem.class);
+        lenient().when(workItem.getProject()).thenReturn(project);
+        lenient().when(workItem.getId()).thenReturn("EL-111");
+        ITypeOpt workItemType = mock(ITypeOpt.class);
+        lenient().when(workItemType.getId()).thenReturn("requirement");
+        lenient().when(workItem.getType()).thenReturn(workItemType);
+
+        // module status that would block the deletion if the hook is not bypassed
+        IModule module = mock(IModule.class);
+        IStatusOpt moduleStatus = mock(IStatusOpt.class);
+        lenient().when(moduleStatus.getId()).thenReturn("in_process");
+        lenient().when(moduleStatus.getName()).thenReturn("In process");
+        lenient().when(module.getStatus()).thenReturn(moduleStatus);
+        lenient().when(module.getModuleName()).thenReturn("TestModule");
+        lenient().when(workItem.getModule()).thenReturn(module);
+
+        return workItem;
+    }
+
+    private DeleteDummyWorkitemsHook createHookWithBypassRoles(String globalRoles, String projectWildcardRoles, String projectSpecificRoles) {
+        String settings = baseSettings()
+                .replace("bypassGlobalRoles=", "bypassGlobalRoles=" + globalRoles)
+                .replace("bypassProjectRoles.*=", "bypassProjectRoles.*=" + projectWildcardRoles);
+        if (projectSpecificRoles != null) {
+            settings += System.lineSeparator() + "bypassProjectRoles.testProject1=" + projectSpecificRoles;
+        }
+        return createHookWithSettings(settings);
+    }
+
+    private DeleteDummyWorkitemsHook createHookWithSettings(String settings) {
+        DeleteDummyWorkitemsHook hook = Mockito.spy(DeleteDummyWorkitemsHook.class);
+        hook.setSettings(new HookModel(true, "1.1.0", settings));
+        return hook;
+    }
+
+    private String baseSettings() {
+        return Mockito.spy(DeleteDummyWorkitemsHook.class).getDefaultSettings();
     }
 }


### PR DESCRIPTION
### Proposed changes

This pull request adds a new feature to the `DeleteDummyWorkitemsHook` allowing users with specific Polarion roles to bypass the hook, both globally and per project. It introduces new configuration options, updates documentation and settings, and provides comprehensive tests to ensure correct behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
