### PR TITLE
chore: sync pre-commit, zizmor, gitignore from template (1/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,9 @@ target/
 dependency-reduced-pom.xml
 
 src/main/resources/webapp/*-admin/html/about.html
+src/main/resources/webapp/*-admin/html/user-guide.html
+src/main/resources/webapp/*-admin/html/disclaimer.html
 README.html
+
+node/
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,14 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        args: [--maxkb=5120]
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: trailing-whitespace
+        exclude_types: [markdown]  # Avoid conflicts with markdown formatting
       - id: check-xml
       - id: check-json
+      - id: check-toml
       - id: check-yaml
       - id: no-commit-to-branch
       - id: mixed-line-ending

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,13 @@
+---
+rules:
+  # These secrets are passed as required step inputs (with:) to third-party actions
+  # (claude-code-action, actions/setup-java) and cannot be moved to env: blocks.
+  # Fork-PR workflows are additionally protected by GitHub's approval requirement.
+  secrets-outside-env:
+    ignore: [claude-code-review.yml, maven-build.yml]
+  # Reusable workflows from our own org — tracking @main intentionally.
+  unpinned-uses:
+    config:
+      policies:
+        '*': hash-pin
+        SchweizerischeBundesbahnen/*: any


### PR DESCRIPTION
## Template sync — config / linting (1 of 4)

Part of the catch-up sync from `open-source-polarion-java-repo-template@3dc98c4`. This is the first PR in the split (gates the rest — pre-commit is the source of truth).

### Changes

- **`.pre-commit-config.yaml`** — structural additions from the template:
  - `check-added-large-files` → `args: [--maxkb=5120]`
  - `trailing-whitespace` → `exclude_types: [markdown]`
  - new `check-toml` hook
  - **Hook revs left unchanged** (commitizen `v4.15.1`, zizmor `v1.24.1`) — version bumps are Renovate's job (`casc-renovate-preset-polarion-java`).
  - **OpenAPI-json hooks skipped** — this repo has no `docs/openapi.json` (same gate that excludes `openapi-validation.yml` / `redocly.yaml`).
- **`zizmor.yml`** — GitHub Actions security-lint config (template #114).
- **`.gitignore`** — template hygiene: `node/`, `node_modules/`, generated `user-guide.html` / `disclaimer.html`.

### Verification

`pre-commit run -a` passes on the full tree.

Refs #74
