### PR TITLE
ci: sync workflows from template — reusable migration, LTS, CodeQL, guard (2/4)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,37 +1,16 @@
 ---
 name: ActionLint
 on:
-  # Run on push to main/master branch
   push:
     branches: [main]
-  # Run on all pull requests
   pull_request:
     branches: ['**']
-  # Allow manual triggering
   workflow_dispatch:
-permissions:
-  contents: read
+permissions: {}
 jobs:
   actionlint:
-    name: Check GitHub Actions Workflows
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-actionlint.yml@main
     permissions:
       checks: write
       contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-      - name: Run actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d  # v1.72.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Report all findings as annotations directly on GitHub
-          reporter: github-check
-          # Error on warnings as well as errors
-          fail_level: error
-          # Comment on the pull request
-          level: error
-          filter_mode: nofilter
+      pull-requests: read

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,14 @@
+---
+name: Add issue to project
+on:
+  issues:
+    types: [opened]
+permissions: {}
+jobs:
+  add-to-project:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-add-issue-to-project.yml@main
+    secrets:
+      POLARION_GITHUB_APP_ID: ${{ secrets.POLARION_GITHUB_APP_ID }}
+      POLARION_GITHUB_APP_PRIVATE_KEY: ${{ secrets.POLARION_GITHUB_APP_PRIVATE_KEY }}
+    with:
+      project-number: ${{ vars.POLARION_GITHUB_PROJECT_NUMBER }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,20 @@
+---
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  claude-review:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+---
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly, off-peak Sunday — matches the cadence default setup uses.
+    - cron: 17 5 * * 0
+permissions: {}
+jobs:
+  analyze:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-codeql-java.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    secrets:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [main, release-v*]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 env:
@@ -60,20 +60,32 @@ jobs:
       - name: 📦 Build with Maven for Pushes
         if: github.event_name == 'push'
         env:
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          IS_PUBLIC: ${{ github.event.repository.visibility == 'public' }}
+          IS_TEMPLATE: ${{ github.event.repository.is_template }}
         run: |
-          if [ -n "${GITHUB_HEAD_REF}" ]; then
-            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
-          else
-            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar
+          SONAR_ARGS=()
+          if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
+            SONAR_ARGS+=(sonar:sonar "-Dsonar.exclusions=.github/**")
+            if [ -n "${BRANCH_NAME}" ]; then
+              SONAR_ARGS+=("-Dsonar.branch.name=${BRANCH_NAME}")
+            fi
           fi
+          mvn --batch-mode -s "${SETTINGS_XML}" clean verify "${SONAR_ARGS[@]}"
       - name: 📦 Build with Maven for PRs
         if: github.event_name == 'pull_request'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}" -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+          IS_PUBLIC: ${{ github.event.repository.visibility == 'public' }}
+          IS_TEMPLATE: ${{ github.event.repository.is_template }}
+        run: |
+          SONAR_ARGS=()
+          if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
+            SONAR_ARGS+=(sonar:sonar "-Dsonar.pullrequest.base=${GITHUB_BASE_REF}" "-Dsonar.pullrequest.branch=${GITHUB_HEAD_REF}" "-Dsonar.pullrequest.key=${GITHUB_PR_NUMBER_REF}" "-Dsonar.exclusions=.github/**")
+          fi
+          mvn --batch-mode -s "${SETTINGS_XML}" clean verify "${SONAR_ARGS[@]}"
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false
@@ -87,9 +99,11 @@ jobs:
             **/target/*.pom
           retention-days: 1
           if-no-files-found: error
+  # Deploy releases to Maven Central from main and LTS branches (release-v*)
+  # See RELEASE.md for LTS branch documentation
   deploy-maven-central:
     needs: build
-    if: ${{ needs.build.outputs.is_release == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -123,10 +137,13 @@ jobs:
             -P central-publishing \
             -Dcentral.timeout=3600 \
             -Dmaven.wagon.http.connectionTimeout=3600000 \
-            -Dmaven.wagon.http.readTimeout=3600000
+            -Dmaven.wagon.http.readTimeout=3600000 \
+            -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
+  # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
+  # LTS branches (release-v*) only upload release assets, no snapshot deployment
   deploy-github-packages:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -154,9 +171,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
       - name: 📦 Deploy to GitHub Packages
-        # Releases should only be deployed to GitHub packages when the repo is private
-        # Only snapshots should always be deployed here
-        if: ${{ needs.build.outputs.is_release == 'false' }}
+        # Releases should only be deployed to GitHub Packages when the repo is private
+        # Snapshots are always deployed to GitHub Packages
+        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,23 +3,9 @@ name: PR checks
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, unlocked]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   check-conventional-commit:
-    name: Check commit messages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: 3.x
-      - run: pip install commitizen
-      - name: Check commit messages
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: cz check --rev-range "$BASE_SHA..$HEAD_SHA"
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-pr.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,11 @@
+---
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,20 +1,22 @@
 ---
+# Release Please Workflow
+# Supports both main branch and LTS (Long-Term Support) branches.
+# LTS branches must follow the naming pattern: release-v{major} (e.g., release-v6)
+# See RELEASE.md for full documentation on LTS releases.
 name: release-please
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-v*  # LTS branches
   workflow_dispatch:
+permissions: {}
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please.yml@main
     permissions:
       contents: write
       pull-requests: write
-      issues: write
-    steps:
-      - name: 🚀 release-please
-        id: release
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5
-        with:
-          release-type: maven
-          target-branch: main
+    with:
+      release-type: maven
+      target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Template sync — workflows (2 of 4)

Part of the catch-up sync from `open-source-polarion-java-repo-template@3dc98c4`. Brings this repo's CI up to the template's reusable-workflow architecture. Builds on #75 (which landed `zizmor.yml`, whose `SchweizerischeBundesbahnen/*: any` rule allows the `@main` reusable-workflow refs below).

### Commit 1 — reusable migration + LTS (template #117, #106)

- `actionlint.yml`, `pr.yml`, `release-please.yml` → call `github-workflows-polarion/.github/workflows/reusable-*.yml@main`.
- `maven-build.yml`: LTS `release-v*` branches, Sonar `IS_PUBLIC`/`IS_TEMPLATE` gating + `-Dsonar.exclusions=.github/**`, `github.ref_name` branch name, LTS deploy conditions.

> ⚠️ **`maven-build.yml` is hand-merged, not copied.** This repo is a **multi-module reactor** (`<packaging>pom</packaging>`, 4 modules); the template is single-module. The template's `target/*.jar` upload glob and single-jar release upload would break here. **Preserved:** `**/target/*.jar` + `**/target/*.pom` upload and `find . -path "*/target/*-${VERSION}.jar" -exec gh release upload …`.

### Commit 2 — new workflows

- `codeql.yml` — CodeQL via `reusable-codeql-java` (template #139).
- `release-please-guard.yml` — block merges during the release danger window (template #123).
- `claude-code-review.yml` — automated PR review (template, #126 perms).
- `add-issue-to-project.yml` — org project board automation.

### ⚙️ Repo-settings to apply **on merge** (not files)

Deferred to merge time so a never-reported required check can't block open PRs before the workflow exists on `main`:

1. **Flip CodeQL default → advanced** — repo is on default setup (`configured`), which silently overrides the synced `codeql.yml`. Coverage trade-off: `reusable-codeql-java` scans **`java-kotlin` only**; the `actions` scanning that default setup did is dropped (actionlint + zizmor still cover workflows).
2. **Recreate `main-requires-release-please-guard` ruleset** (missing) — required check `release-please-guard / release-please-guard`, **strict**, verbatim from the template. Without it the guard workflow is toothless. (`main-requires-status-checks` already exists.)

Confirm the org project board covers this repo (`add-issue-to-project.yml`).

Refs #74
