### PR TITLE
chore(deps): bump generic app version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <ch.sbb.polarion.extension.interceptor-manager.version>7.1.0</ch.sbb.polarion.extension.interceptor-manager.version>
-        <ch.sbb.polarion.extension.generic.app.version>15.4.2</ch.sbb.polarion.extension.generic.app.version>
+        <ch.sbb.polarion.extension.generic.app.version>15.5.0</ch.sbb.polarion.extension.generic.app.version>
 
         <interceptor-manager.artifactId>ch.sbb.polarion.extension.interceptor-manager</interceptor-manager.artifactId>
         <hooks.folder.name>hooks</hooks.folder.name>


### PR DESCRIPTION
### Proposed changes

This pull request updates a dependency version in the `pom.xml` file. The version of `ch.sbb.polarion.extension.generic.app` has been bumped from `15.4.2` to `15.5.0` to include the latest features or fixes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
