### PR TITLE
ci: drop the dead markdown2html env var

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
       GITHUB_TOKEN: ${{ github.token }}  # Providing this prevents reaching the GitHub request limits
     steps:
       - name: 📄 Checkout the repository


### PR DESCRIPTION
### Proposed changes

`maven-build.yml` exported `MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR`, but nothing in this repository reads it - no pom interpolates `${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}`, so the variable had no effect on any build.

It came from the pattern the extensions used to gate the `README.md` -> `about.html` conversion in CI only. Those repositories now set `markdown2html-maven-plugin.failOnError` directly: markdown2html renders the markdown locally since 1.7.x - no GitHub API call and no token - so there is nothing environment-dependent left to toggle, and the env indirection also only covered the `build` job while the deploy job re-ran the conversion ungated.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
